### PR TITLE
Add sign out link to navbar for all pages where authentication was required.  Fixes #63

### DIFF
--- a/templates/fleet/home.html
+++ b/templates/fleet/home.html
@@ -5,8 +5,8 @@
 {% block content %}
 
   <nav aria-label="breadcrumb">
-    <ol class="breadcrumb my-auto">
-      <li class="breadcrumb-item active my-auto" aria-current="page">Home</li>
+    <ol class="breadcrumb">
+      <li class="breadcrumb-item my-auto active" aria-current="page">Home</li>
       <li class="ml-auto my-auto small">welcome, {{ user }}</li>
       <a href="{% url "user sign out" %}"
          class="btn btn-outline-primary btn-sm ml-2"

--- a/templates/inventory/make_station_order.html
+++ b/templates/inventory/make_station_order.html
@@ -5,9 +5,14 @@
 {% block content %}
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
-      <li class="breadcrumb-item"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
-      <li class="breadcrumb-item active" aria-current="page">Order #{{ order_pk }}</li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'home' %}">Home</a></li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
+      <li class="breadcrumb-item my-auto active" aria-current="page">Order #{{ order_pk }}</li>
+      <li class="ml-auto my-auto small">welcome, {{ user }}</li>
+      <a href="{% url "user sign out" %}"
+         class="btn btn-outline-primary btn-sm ml-2"
+         role="button">sign out
+      </a>
     </ol>
   </nav>
 

--- a/templates/inventory/make_vehicle_order.html
+++ b/templates/inventory/make_vehicle_order.html
@@ -5,10 +5,15 @@
 {% block content %}
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
-      <li class="breadcrumb-item"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
-      <li class="breadcrumb-item"><a href="{% url 'make station order' station_id=station_id order_pk=order_pk %}">Order #{{ order_pk }}</a></li>
-      <li class="breadcrumb-item active" aria-current="page">{{ vehicle_name }}</li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'home' %}">Home</a></li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'make station order' station_id=station_id order_pk=order_pk %}">Order #{{ order_pk }}</a></li>
+      <li class="breadcrumb-item my-auto active" aria-current="page">{{ vehicle_name }}</li>
+      <li class="ml-auto my-auto small">welcome, {{ user }}</li>
+      <a href="{% url "user sign out" %}"
+         class="btn btn-outline-primary btn-sm ml-2"
+         role="button">sign out
+      </a>
     </ol>
   </nav>
 

--- a/templates/inventory/station_order_confirmation.html
+++ b/templates/inventory/station_order_confirmation.html
@@ -5,9 +5,14 @@
 {% block content %}
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
-      <li class="breadcrumb-item"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
-      <li class="breadcrumb-item active" aria-current="page">Order #{{ order_pk }}</li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'home' %}">Home</a></li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
+      <li class="breadcrumb-item my-auto active" aria-current="page">Order #{{ order_pk }}</li>
+      <li class="ml-auto my-auto small">welcome, {{ user }}</li>
+      <a href="{% url "user sign out" %}"
+         class="btn btn-outline-primary btn-sm ml-2"
+         role="button">sign out
+      </a>
     </ol>
   </nav>
 

--- a/templates/inventory/station_order_summary.html
+++ b/templates/inventory/station_order_summary.html
@@ -5,9 +5,14 @@
 {% block content %}
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
-      <li class="breadcrumb-item"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
-      <li class="breadcrumb-item active" aria-current="page">Order #{{ order_pk }}</li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'home' %}">Home</a></li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'station orders dashboard' station_id=station_id %}">{{ station_name }}</a></li>
+      <li class="breadcrumb-item my-auto active" aria-current="page">Order #{{ order_pk }}</li>
+      <li class="ml-auto my-auto small">welcome, {{ user }}</li>
+      <a href="{% url "user sign out" %}"
+         class="btn btn-outline-primary btn-sm ml-2"
+         role="button">sign out
+      </a>
     </ol>
   </nav>
 

--- a/templates/inventory/station_orders_dashboard.html
+++ b/templates/inventory/station_orders_dashboard.html
@@ -5,8 +5,13 @@
 {% block content %}
   <nav aria-label="breadcrumb">
     <ol class="breadcrumb">
-      <li class="breadcrumb-item"><a href="{% url 'home' %}">Home</a></li>
-      <li class="breadcrumb-item active" aria-current="page">{{ station_name }}</li>
+      <li class="breadcrumb-item my-auto"><a href="{% url 'home' %}">Home</a></li>
+      <li class="breadcrumb-item my-auto active " aria-current="page">{{ station_name }}</li>
+      <li class="ml-auto my-auto small">welcome, {{ user }}</li>
+      <a href="{% url "user sign out" %}"
+         class="btn btn-outline-primary btn-sm ml-2"
+         role="button">sign out
+      </a>
     </ol>
   </nav>
 


### PR DESCRIPTION
This addition to navbar introduced unnecessary redundancy to the following files:
* home.html
* make_station_order.html
* make_vehicle_order.html
* station_order_confirmation.html
* station_order_summary.html
* station_orders_dashboard.html

which violates DRY principle and shall be addressed.
