### PR TITLE
Test that user can not sign in without entering valid username-password on the sign_in page.

### DIFF
--- a/pages/base.py
+++ b/pages/base.py
@@ -2,5 +2,12 @@ class BasePage:
 
     BASE_URL = 'http://localhost:8000'
 
-    def __init__(self, browser):
+    def __init__(self, url, browser):
+        self.url = url
         self.browser = browser
+
+    def make_url(self, path):
+        return self.BASE_URL + path
+
+    def load(self):
+        self.browser.get(self.url)

--- a/pages/base.py
+++ b/pages/base.py
@@ -1,0 +1,6 @@
+class BasePage:
+
+    BASE_URL = 'http://localhost:8000'
+
+    def __init__(self, browser):
+        self.browser = browser

--- a/pages/sign_in.py
+++ b/pages/sign_in.py
@@ -10,12 +10,9 @@ class SignInPage(BasePage):
     PASSWORD_FIELD_LOCATOR = (By.ID, 'inputPassword')
     SIGN_IN_BUTTON_LOCATOR = (By.CSS_SELECTOR, 'button[type="submit"]')
 
-    def get_url(self):
-        return self.BASE_URL + self.PATH
-
-    def load(self):
-        url = self.get_url()
-        self.browser.get(url)
+    def __init__(self, browser):
+        url = self.make_url(self.PATH)
+        BasePage.__init__(self, url, browser)
 
     def sign_in(self, username, password):
         username_field = self.browser.find_element(*self.USERNAME_FIELD_LOCATOR)

--- a/pages/sign_in.py
+++ b/pages/sign_in.py
@@ -4,7 +4,8 @@ from pages.accounts import TestAccount
 
 class SignInPage:
 
-    URL = 'http://localhost:8000/jcc/signin'
+    DOMAIN = 'http://localhost:8000'
+    PATH = '/jcc/signin'
 
     USERNAME_FIELD_LOCATOR = (By.ID, 'inputUsername')
     PASSWORD_FIELD_LOCATOR = (By.ID, 'inputPassword')
@@ -13,8 +14,12 @@ class SignInPage:
     def __init__(self, browser):
         self.browser = browser
 
+    def get_url(self):
+        return self.DOMAIN + self.PATH
+
     def load(self):
-        self.browser.get(self.URL)
+        url = self.get_url()
+        self.browser.get(url)
 
     def log_in(self):
         username_field = self.browser.find_element(*self.USERNAME_FIELD_LOCATOR)
@@ -22,6 +27,16 @@ class SignInPage:
 
         password_field = self.browser.find_element(*self.PASSWORD_FIELD_LOCATOR)
         password_field.send_keys(TestAccount.password)
+
+        sign_in_button = self.browser.find_element(*self.SIGN_IN_BUTTON_LOCATOR)
+        sign_in_button.click()
+
+    def sign_in_with_credentials(self, username, password):
+        username_field = self.browser.find_element(*self.USERNAME_FIELD_LOCATOR)
+        username_field.send_keys(username)
+
+        password_field = self.browser.find_element(*self.PASSWORD_FIELD_LOCATOR)
+        password_field.send_keys(password)
 
         sign_in_button = self.browser.find_element(*self.SIGN_IN_BUTTON_LOCATOR)
         sign_in_button.click()

--- a/pages/sign_in.py
+++ b/pages/sign_in.py
@@ -1,20 +1,17 @@
+from pages.base import BasePage
 from selenium.webdriver.common.by import By
 
 
-class SignInPage:
+class SignInPage(BasePage):
 
-    DOMAIN = 'http://localhost:8000'
     PATH = '/jcc/signin'
 
     USERNAME_FIELD_LOCATOR = (By.ID, 'inputUsername')
     PASSWORD_FIELD_LOCATOR = (By.ID, 'inputPassword')
     SIGN_IN_BUTTON_LOCATOR = (By.CSS_SELECTOR, 'button[type="submit"]')
 
-    def __init__(self, browser):
-        self.browser = browser
-
     def get_url(self):
-        return self.DOMAIN + self.PATH
+        return self.BASE_URL + self.PATH
 
     def load(self):
         url = self.get_url()

--- a/pages/sign_in.py
+++ b/pages/sign_in.py
@@ -1,5 +1,4 @@
 from selenium.webdriver.common.by import By
-from pages.accounts import TestAccount
 
 
 class SignInPage:
@@ -21,17 +20,7 @@ class SignInPage:
         url = self.get_url()
         self.browser.get(url)
 
-    def log_in(self):
-        username_field = self.browser.find_element(*self.USERNAME_FIELD_LOCATOR)
-        username_field.send_keys(TestAccount.username)
-
-        password_field = self.browser.find_element(*self.PASSWORD_FIELD_LOCATOR)
-        password_field.send_keys(TestAccount.password)
-
-        sign_in_button = self.browser.find_element(*self.SIGN_IN_BUTTON_LOCATOR)
-        sign_in_button.click()
-
-    def sign_in_with_credentials(self, username, password):
+    def sign_in(self, username, password):
         username_field = self.browser.find_element(*self.USERNAME_FIELD_LOCATOR)
         username_field.send_keys(username)
 

--- a/pages/stations.py
+++ b/pages/stations.py
@@ -1,20 +1,20 @@
+from pages.base import BasePage
 from selenium.webdriver.common.by import By
 import selenium.common.exceptions
 
 
-class StationsPage:
+class StationsPage(BasePage):
 
-    DOMAIN = 'http://localhost:8000'
     PATH = '/jcc/stations'
 
     WELCOME_USER_MESSAGE_LOCATOR = (By.CSS_SELECTOR, 'ol.breadcrumb li:nth-child(2)')
 
-    def __init__(self, browser):
-        self.browser = browser
+    def get_url(self):
+        return self.BASE_URL + self.PATH
 
     def load(self):
-        url = self.DOMAIN + self.PATH
-        return self.browser.get(url)
+        url = self.get_url()
+        self.browser.get(url)
 
     def get_page_title(self):
         try:

--- a/pages/stations.py
+++ b/pages/stations.py
@@ -1,7 +1,30 @@
+from selenium.webdriver.common.by import By
+import selenium.common.exceptions
+
+
 class StationsPage:
+
+    DOMAIN = 'http://localhost:8000'
+    PATH = '/jcc/stations'
+
+    WELCOME_USER_MESSAGE_LOCATOR = (By.CSS_SELECTOR, 'ol.breadcrumb li:nth-child(2)')
 
     def __init__(self, browser):
         self.browser = browser
 
+    def load(self):
+        url = self.DOMAIN + self.PATH
+        return self.browser.get(url)
+
     def get_page_title(self):
-        return self.browser.title
+        try:
+            return self.browser.title
+        except selenium.common.exceptions.NoSuchElementException:
+            return None
+
+    def get_welcome_user_message(self):
+        try:
+            welcome_user_message_field = self.browser.find_element(*self.WELCOME_USER_MESSAGE_LOCATOR)
+            return welcome_user_message_field.text
+        except selenium.common.exceptions.NoSuchElementException:
+            return None

--- a/pages/stations.py
+++ b/pages/stations.py
@@ -9,12 +9,9 @@ class StationsPage(BasePage):
 
     WELCOME_USER_MESSAGE_LOCATOR = (By.CSS_SELECTOR, 'ol.breadcrumb li:nth-child(2)')
 
-    def get_url(self):
-        return self.BASE_URL + self.PATH
-
-    def load(self):
-        url = self.get_url()
-        self.browser.get(url)
+    def __init__(self, browser):
+        url = self.make_url(self.PATH)
+        BasePage.__init__(self, url, browser)
 
     def get_page_title(self):
         try:

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -3,11 +3,15 @@ from pages.stations import StationsPage
 from pages.accounts import TestAccount
 
 
-def test_user_can_login(browser):
+def test_user_can_sign_in(browser):
     sign_in_page = SignInPage(browser)
-
     sign_in_page.load()
-    sign_in_page.log_in()
+
+    username = TestAccount.username
+    password = TestAccount.password
+
+    sign_in_page.sign_in(username=username,
+                         password=password)
 
     stations_page = StationsPage(browser)
     stations_page_title = stations_page.get_page_title()
@@ -15,15 +19,15 @@ def test_user_can_login(browser):
     assert stations_page_title == 'Stations'
 
 
-def test_user_signs_in_with_invalid_password(browser):
+def test_user_cant_sign_in_with_invalid_password(browser):
     sign_in_page = SignInPage(browser)
     sign_in_page.load()
 
     username = TestAccount.username
     invalid_password = 'Invalid_Pa$$w0rd'
 
-    sign_in_page.sign_in_with_credentials(username=username,
-                                          password=invalid_password)
+    sign_in_page.sign_in(username=username,
+                         password=invalid_password)
 
     sign_in_page_url = sign_in_page.get_url()
     assert browser.current_url == sign_in_page_url

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,5 +1,6 @@
 from pages.sign_in import SignInPage
 from pages.stations import StationsPage
+from pages.accounts import TestAccount
 
 
 def test_user_can_login(browser):
@@ -12,3 +13,29 @@ def test_user_can_login(browser):
     stations_page_title = stations_page.get_page_title()
 
     assert stations_page_title == 'Stations'
+
+
+def test_user_signs_in_with_invalid_password(browser):
+    sign_in_page = SignInPage(browser)
+    sign_in_page.load()
+
+    username = TestAccount.username
+    invalid_password = 'Invalid_Pa$$w0rd'
+
+    sign_in_page.sign_in_with_credentials(username=username,
+                                          password=invalid_password)
+
+    sign_in_page_url = sign_in_page.get_url()
+    assert browser.current_url == sign_in_page_url
+
+    stations_page = StationsPage(browser)
+    stations_page.load()
+
+    station_page_title = stations_page.get_page_title()
+    assert station_page_title == 'Sign In'
+
+    welcome_user_message = stations_page.get_welcome_user_message()
+    assert welcome_user_message is None
+
+    redirect_to_sign_in_url = '%s?next=%s' % (sign_in_page_url, StationsPage.PATH)
+    assert browser.current_url == redirect_to_sign_in_url

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,7 +1,6 @@
 from pages.sign_in import SignInPage
 from pages.stations import StationsPage
 from pages.accounts import TestAccount
-from urllib.parse import urljoin
 
 
 def test_user_can_sign_in(browser):
@@ -30,7 +29,7 @@ def test_user_cant_sign_in_with_invalid_password(browser):
     sign_in_page.sign_in(username=username,
                          password=invalid_password)
 
-    sign_in_page_url = sign_in_page.get_url()
+    sign_in_page_url = sign_in_page.url
     assert browser.current_url == sign_in_page_url
 
     stations_page = StationsPage(browser)

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,6 +1,7 @@
 from pages.sign_in import SignInPage
 from pages.stations import StationsPage
 from pages.accounts import TestAccount
+from urllib.parse import urljoin
 
 
 def test_user_can_sign_in(browser):


### PR DESCRIPTION
Added test that verifies the following:
* User unable to see `Stations` page without entering valid username-password on the `Sign In` page,
* User is redirected to the `Sign In` page if attempts to access `Stations` bypassing `Sign In`,
* Unsuccessful sign attempt keeps the user on the `Sign In` page.